### PR TITLE
Create documentation issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,7 +1,6 @@
-name: Documentation errors
+name: Documentation errors & requests
 description: Let us know about typos and goofs in our site, documentation or API documentation blocks
-title: "[Docs]: "
-labels: ["documentation", "api"]
+labels: ["documentation"]
 body:
   - type: markdown
     attributes:
@@ -11,11 +10,12 @@ body:
   - type: dropdown
     id: course-where
     attributes:
-      label: Where did you find it?
+      label: Where did you find it, or where does it belong for requests?
       options: 
        - Main Foundry site (not package listings)
-       - API site
-       - Code documentation comments
+       - V10 API Documentation (https://foundryvtt.com/api/v10/)
+       - V9 API Documentation (https://foundryvtt.com/api/)
+       - Code documentation comments (foundry.js)
     validations:
       required: true
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,50 @@
+name: Documentation errors
+description: Let us know about typos and goofs in our site, documentation or API documentation blocks
+title: "[Docs]: "
+labels: ["documentation", "api"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to report a mistake or discrepancy with the core Foundry software site,
+        documentation, or code documentation comments.
+  - type: dropdown
+    id: course-where
+    attributes:
+      label: Where did you find it?
+      options: 
+       - Main Foundry site (not package listings)
+       - API site
+       - Code documentation comments
+    validations:
+      required: true
+  - type: markdown
+    attributes:
+      value: |
+        Any issues with the content on pages for packages should be addressed to the authors
+        of said packages, even for premium content. For premium content managed directly by
+        the Foundry team, [which are all listed here][1], issues should be [submitted here][2].
+
+        [1]: https://github.com/foundryvtt/foundryvtt-premium-content/blob/main/README.md
+        [2]: https://github.com/foundryvtt/foundryvtt-premium-content/issues
+  - type: input
+    id: fine-where
+    attributes:
+      label: What page or file needs a look at?
+      description: For existing documentation, paste the URL or file path of a script so we can see it.
+      placeholder: https://foundryvtt.com/[...] resource/app/scripts/[...]
+  - type: input
+    id: version
+    attributes:
+      label: What core version are you reporting this for?
+      description:  For the API code documentation comments in scripts. Include, at minimum, the build number
+      placeholder: Version 10 Testing 1 (build 274)
+      value: "Version 10 Testing 1 (build 274)"
+  - type: textarea
+    id: whats-wrong
+    attributes:
+      label: What is wrong, in your opinion?
+      description: Also tell us, what did you expect to see or for something to be?
+      placeholder: Tell us what you see!
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -24,6 +24,9 @@ body:
         Any issues with the content on pages for packages should be addressed to the authors
         of said packages, even for premium content. For premium content managed directly by
         the Foundry team, [which are all listed here][1], issues should be [submitted here][2].
+        For all other packages, please see the page for the package in question and look for
+        either the project URL (found after the description, but right before the version list)
+        or for a support link in the description.
 
         [1]: https://github.com/foundryvtt/foundryvtt-premium-content/blob/main/README.md
         [2]: https://github.com/foundryvtt/foundryvtt-premium-content/issues


### PR DESCRIPTION
As per the [conversation here](https://discord.com/channels/170995199584108546/893621333538258944/1003434850692386856), here is the PR for adding a documentation issue template, with a bit of back and forth done with mxzf to take off the rougher edges.