### PR TITLE
Changes to EULA and Privacy Policy for usage data

### DIFF
--- a/articles/eula.html
+++ b/articles/eula.html
@@ -1,38 +1,42 @@
-<h1>Foundry Virtual Tabletop End User License Agreement</h1>
-<h5>Updated October 30, 2022</h5>
+<h1 id="license-title">Foundry Virtual Tabletop End User License Agreement</h1>
+<h5>Updated March 2, 2023 - Version 11.293</h5>
 
-<blockquote class="question">This license agreement applies to Foundry Virtual Tabletop, also referred to as "software", "the software", or "this software".</blockquote>
-<p>As a software license owner, you are granted permission to install and use the software if you agree to all of the following terms:</p>
-<ol>
+<p><strong>This license agreement applies to Foundry Virtual Tabletop, also referred to as "software", "the software", or "this software".</strong></p>
+<p>As a software license owner, you are granted permission to install and use the software if you agree to the following terms:</p>
+<ol class="terms">
+<li>You must maintain a user account on the <a href="https://foundryvtt.com/" target="_blank" rel="nofollow noopener">Foundry Virtual Tabletop website</a> which provides an email address where you may be contacted if necessary.</li>
 <li>You may install and activate the software on one or more computers, but only one hosted instance of the software may be accessible to users other than the license owner at any given time. Hosting multiple accessible instances of the software is permitted by owning a corresponding number of software licenses.</li>
-<li>You may create backup copies of the software for personal archival purposes but you may not distribute those copies.</li>
-<li>You may not lease or sell the software or its license for direct or indirect financial gain. You may accept payment in exchange for services related to the software, for example running game sessions or providing technical support.</li>
+<li>You may create backup copies of the software for personal archival purposes, but you may not distribute those copies.</li>
+<li>You may not lease or sell the software, software license key, or access to the software. You may accept payment in exchange for services related to the software, for example running game sessions or providing technical support.</li>
 <li>You may share the software and its license key with a friend or family member provided the other terms of the license are upheld.</li>
-<li>You may, within 30 days of purchase, permanently transfer your license to another party who will become bound by this agreement. To transfer your license you must use the provided form on the Foundry Virtual Tabletop website. After transfer of your license you may not retain any copies of the software unless you own a valid license.</li>
-<li>You may, within 30 days of purchase, request to return a purchased license in exchange for a full refund.</li>
-<li>You may retain ownership to any personal data created within the software, even if you relinquish or transfer your license to the software. You bear the sole responsibility to uphold any user agreements, licensing terms, or terms of service related to that content.</li>
+<li>You may, within 30 days of purchase, permanently transfer your license to another party who will become bound by this agreement using the <a href="https://foundryvtt.com/purchase/transfer" target="_blank" rel="nofollow noopener">License Transfer Form</a> on the Foundry Virtual Tabletop website. After transfer of your license you may not retain any copies of the software unless you own a valid license.</li>
+<li>You may, within 30 days of purchase, request to return a purchased license in exchange for a full refund in accordance with our Refund Policy using the <a href="https://foundryvtt.com/purchase/refund" target="_blank" rel="nofollow noopener">Refund Request Form</a> on the Foundry Virtual Tabletop website.</li>
+<li>You may not use the software to facilitate or engage in the illegal distribution of copyright protected materials.</li>
+<li>You retain ownership to any personal data created within the software even if you relinquish or transfer your license to the software. You bear the sole responsibility to uphold any user agreements, licensing terms, or terms of service related to that content.</li>
 </ol>
-<p>If you do not agree to the terms of this license you must remove all copies of the software from your computer and request a refund, if eligible, via the <a href="https://foundryvtt.com/me/licenses" target="_blank">Purchased Licenses</a> page of your user profile on the foundryvtt.com website.
+<p>If you do not agree to the terms of this license you must remove all copies of the software from your computer and request a refund, if eligible.</p>
+<p>If your usage of the software violates these terms, we will contact you via the email address of your website account. Repeated or egregious violation may result in a suspension of your software license key at our discretion.</p>
 <p>This software is protected by the copyright laws of the United States and other countries. Foundry Gaming LLC retains all intellectual property rights in the software. You may not separately sell, market, distribute, lend, lease, rent, or sublicense the software including its license key. You may not separately publish any portions of the software except under the provisions outlined in the following section regarding authorized module development. This license is not to be construed as prohibiting or limiting any fair use sanctioned by copyright law.</p>
 
-<h2 class="border">Limited License Agreement for Module Development</h2>
-<p>As a software license owner, you are granted license to develop software packages which extend the functionality of the software if you agree to all of the following terms:</p>
-<ol>
-<li>You may create packages, which include game systems, add-on modules, and worlds which reference or duplicate portions of the software code. Publication of packages which reference or include software code and function in the absence of the base software is not permitted. Including portions of software code is only permitted as is strictly necessary for proper functioning of the package.</li>
+<h2 class="border">Limited License for Package Development</h2>
+<p>As a software license owner, you are granted license to develop Game Systems, Add-on Modules, and Worlds, referred to as "packages", which extend the functionality of the software if you agree to the following terms:</p>
+<ol class="terms">
+<li>You may create packages which utilize, reference, or duplicate portions of the software code. Publication of packages which reference or include software code and function in the absence of the base software is not permitted. Including portions of software code is only permitted to the extent strictly necessary for proper functioning of the package.</li>
 <li>You may distribute these packages provided they are designed to be used only in conjunction with a licensed copy of the software.</li>
 <li>You are allowed to sell or lease package content which you have the rights to distribute. You bear the sole responsibility to uphold intellectual property rights as required by copyright law.</li>
-<li>The publication of package content is bound by the terms of the most recent available version of this agreement found on the <a title="Foundry VTT License" href="/article/license" target="_blank" rel="nofollow noopener">Foundry Virtual Tabletop</a> website. Any modifications of this policy shall not retroactively alter or revoke the rights given under the previous limited license. When you publish changes to an existing package, it becomes bound by the most recent terms of this agreement.</li>
+<li>The publication of package content is bound by the terms of the most recent available version of this <a href="https://foundryvtt.com/article/license" target="_blank" rel="nofollow noopener">Software License</a> agreement found on the Foundry Virtual Tabletop website. Any modifications of this policy shall not retroactively alter or revoke the rights given under the previous limited license. When you publish changes to an existing package, it becomes bound by the most recent terms of this agreement.</li>
 </ol>
 <p>If you do not agree to the terms of this license, you may not publish package content. Any existing packages that were created under a previous version of this agreement may remain published provided they adhere to the license terms under which they were published.</p>
 
 <h2 class="border">Limited Warranty</h2>
-<p>We warrant that purchased copies of the software will provide the features and functions generally described in the product specifications on the <a rel="nofollow">Foundry Virtual Tabletop</a> website at the time of purchase. We have taken reasonable steps to keep the software free of viruses, spyware, back-door entrances, or any other harmful code.</p>
-<p>When requesting to install updates to the software, your license key, host location, and acceptance of this agreement will be recorded in order to verify your authorization to obtain software updates. Apart from this case, the software will not track or collect any information about you, your data, or your usage of the software.</p>
-<p>The software will not download or install patches, upgrades, or any third party software without first obtaining your permission. We will not intentionally deprive you of your ability to use any features of the software or access your data. We do not warrant that the software, or your ability to use it, will be uninterrupted or error-free.</p>
+<p>We warrant that purchased copies of the software will provide the features and functions generally described in the product specifications on the Foundry Virtual Tabletop website at the time of purchase. We have taken reasonable steps to keep the software free of viruses, spyware, back-door entrances, or any other harmful code.</p>
+<p>When requesting to install updates to the software, your license key, host address, and acceptance of this agreement will be recorded in order to verify your authorization to obtain software updates. Apart from this workflow, the software does not collect any information about you which is personally identifiable.</p>
+<p>The software may collect anonymous usage data and may share that data with us only if you authorize the software to do so as described by our <a href="https://foundryvtt.com/article/privacy-policy/" target="_blank" rel="nofollow noopener">Privacy Policy</a>.</p>
+<p>The software will not download or install patches, upgrades, or any third party material without first obtaining your permission. We will not intentionally deprive you of your ability to use any features of the software or access your data. We do not warrant that the software, or your ability to use it, will be uninterrupted or error-free.</p>
 <p>Your exclusive remedy under the above limited warranty is the right to request a full refund of the purchase price of the software within 30 days of your original purchase.</p>
 
 <h2 class="border">General Provisions</h2>
 <p>If any part of this agreement is found to be invalid or unenforceable, the remaining terms will stay in effect. This agreement does not prejudice the statutory rights of any party dealing as a consumer. Modification of this agreement is not permitted unless accepted in writing or by digital signature of both parties. This agreement applies from the date that such acceptance is provided by the license owner.</p>
 <p>This Agreement shall be governed under the laws of the United States of America and the State of Washington.</p>
 
-<p class="note">Foundry Gaming LLC © 2022. End User License Agreement</p>
+<p class="copyright">Foundry Gaming LLC © 2023. End User License Agreement</p>

--- a/articles/privacy.html
+++ b/articles/privacy.html
@@ -1,39 +1,129 @@
-<h5>Updated July 3, 2022</h5>
-<p>This policy describes your rights under GDPR and other legislation which is designed to protect privacy of your personal information. Foundry Virtual Tabletop is committed to protecting your personal privacy while using our website <a href="https://foundryvtt.com" title="The Foundry Virtual Tabletop Website">https://foundryvtt.com</a> and the Foundry Virtual Tabletop application. This policy describes what data we collect and persist, and under what circumstances it is used. This document will be updated from time to time - the date of the most recent revision will be reflected at the top of the document.</p>
+<h5>Updated March 2, 2023</h5>
+<p>This policy describes our approach towards data collection and describes your rights under GDPR or other legislation which is designed to protect privacy of your personal information. Foundry Virtual Tabletop is committed to protecting your personal privacy while using our website <a href="https://foundryvtt.com" title="The Foundry Virtual Tabletop Website">https://foundryvtt.com</a> and the Foundry Virtual Tabletop application. This policy describes what data we collect and persist, and under what circumstances it is used. This document will be updated from time to time - the date of the most recent revision will be reflected at the top of the document.</p>
 
-<h2 class="border">Collected Data</h2>
+<h2 class="border">This Website</h2>
 
 <blockquote class="question">What personal information does the website collect, and how is that information used?</blockquote>
 <p>When you browse the <a href="https://foundryvtt.com" title="The Foundry Virtual Tabletop Website">Foundry Virtual Tabletop website</a> ("the website"), we record your IP address in order to detect and mitigate risks from potentially abusive browsing behavior.</p>
 
-<p>If you register a user account on the website, your username, email address, chosen password, and other optional details are stored as part of your individual user data. This information is used to provide you with account services related to your Foundry Virtual Tabletop software license (if any).</p>
-
-<p>The website does not use your personal information as an input into any automated decision making system.</p>
+<p>If you register a user account on the website, your username, email address, chosen password, and other optional details are stored as part of your individual user data. This information is used to provide you with account services related to your Foundry Virtual Tabletop software license and your participation in the Foundry Virtual Tabletop community. The website does not use your personal information as an input into any automated decision-making system.</p>
 
 <blockquote class="question">What information does the website share with other services?</blockquote>
 
-<h4>Google</h4>
+<h5>Google Analytics</h5>
 <p>If you accept the website privacy policy, your IP address is shared with Google Analytics. This data assists us to understand where our customers are visiting from, how they discovered Foundry Virtual Tabletop, and which advertising or promotional channels are working most effectively for us grow our business and improve our software. You may review the <a href="https://policies.google.com/privacy?hl=en_US" title="Google Privacy and Terms" target="_blank">Google Privacy & Terms</a> policy for more details on the data that Google collects and how it may be used.</p>
 
-<h4>Stripe</h4>
+<h5>Stripe</h5>
 <p>If you choose to purchase the Foundry Virtual Tabletop software your email address is provided to Stripe who provides payment processing services for Foundry Gaming LLC. You may review the <a href="https://stripe.com/gb/privacy" title="Stripe Privacy Policy" target="_blank">Stripe privacy policy</a> for details on their use of this data in order to provide secure payment processing services.</p>
 
 <blockquote class="question">How and why does the website use cookies?</blockquote>
-<p>We use cookies in order to store your browsing session which allows you to navigate the website without being prompted to log in on every page. This session cookie is important to the experience of interacting with the website and cannot be disabled.</p>
+<p>We use cookies in order to store your browsing session which allows you to navigate the website without being prompted to log in on every page. This session cookie is essential to the functionality of interacting with this website and cannot be disabled.</p>
+
+<h2 class="border">The Foundry Virtual Tabletop Software</h2>
 
 <blockquote class="question">What personal data does the application collect?</blockquote>
-<p>The Foundry Virtual Tabletop software itself does not collect or store any personal information. The software stores your signed software license key - which is not personally identifiable - and transmits this key to the website when needed to perform license verification checks. When those checks are made, we record and store the IP address from which you updated the Foundry Virtual Tabletop software.</p>
+<p>If you purchase and use the Foundry Virtual Tabletop software, you will be prompted to agree to our <a href="./license" target="_blank">End User License Agreement</a>. When you agree to this EULA your software license key is signed by our website. As part of that process we record the IP address of the host machine where you activated the Foundry Virtual Tabletop software.
+
+<p>The Foundry Virtual Tabletop software stores your software license key - which is not personally identifiable - and uses this software license key to periodically check with this website to verify your access and check for available software updates.</p>
+
+<blockquote class="question">What usage data does the application collect?</blockquote>
+<p>As a user of Foundry Virtual Tabletop you may enable an optional setting to <span class="reference">Share Usage Data</span> which shares additional data with us that helps us to improve Foundry Virtual Tabletop. This data helps us to answer questions like "which Foundry Virtual Tabletop software versions are most widely used?", "which Game Systems are most frequently played?", and "how many of our users host on macOS compared to Linux?".</p>
+
+<p>The usage data collected by the software does not contain any personally identifying information and is not shared directly with any other party.  For transparency, the Foundry Virtual Tabletop software saves the usage data it collects in your user data folder in the <span class="reference">Logs/diagnostics.json</span> file. Below is presented a real example of the usage data the software collects. This collected data is <strong>only</strong> shared with us if the <span class="reference">Share Usage Data</span> setting is enabled. This setting is initially disabled and can be re-disabled at any point after it has been enabled.</p>
+
+<section class="collapsible">
+    <header class="collapsible-header">Example Usage Data</header>
+    <div class="collapsible-content"><pre><code class="language-json">{
+  "timestamp": 1677769428480,
+  "os": {
+    "platform": "win32",
+    "version": "Windows 10 Pro",
+    "node": "18.13.0"
+  },
+  "foundry": {
+    "generation": 11,
+    "build": 292,
+    "channel": "prototype",
+    "hosting": null
+  },
+  "modules": {
+    "atropos-maps": {
+      "version": "1.4.0"
+    },
+    "caeora-maps-tokens-assets": {
+      "version": "2.1.3"
+    },
+    "demon-queen-awakens": {
+      "version": "1.1.1"
+    },
+    "dice-so-nice": {
+      "version": "4.6.5"
+    },
+    "gameboard-support": {
+      "version": "1.0.5"
+    },
+    "house-divided": {
+      "version": "1.1.2"
+    },
+    "michaelghelfi": {
+      "version": "1.3"
+    },
+    "pf2e-abomination-vaults": {
+      "version": "1.2.0"
+    },
+    "pf2e-beginner-box": {
+      "version": "2.2.0"
+    },
+    "token-action-hud-core": {
+      "version": "1.2.3"
+    },
+    "token-action-hud-dnd5e": {
+      "version": "1.2.2"
+    },
+    "touch-vtt": {
+      "version": "1.9.1"
+    },
+    "trs-housedivided-dice-set": {
+      "version": "1.0.1"
+    },
+    "trs-metal-rainbow": {
+      "version": "1.0.0"
+    }
+  },
+  "systems": {
+    "dnd5e": {
+      "version": "2.1.5",
+      "playtime": 25306
+    },
+    "pf2e": {
+      "version": "4.7.2"
+    },
+    "worldbuilding": {
+      "version": "0.7.2",
+      "playtime": 0
+    }
+  },
+  "worlds": {},
+  "playtime": {
+    "total": 129731,
+    "max": 104425
+  }
+}</code></pre></div>
+</section>
+
+<blockquote class="question">Which installed Worlds, Game Systems, or Add-on Modules does the software collect data about?</blockquote>
+<p>The software collects usage data for packages which are configured by their author to be publicly installable by defining a <code>manifest</code> URL. The software does not collect data about your own personal Worlds or about any package that is developed for personal use only and does not define a public manifest URL.</p>
+
+<h2 class="border">Data Management</h2>
 
 <blockquote class="question">How is the data you collect kept secure?</blockquote>
-<p>We do NOT collect or store any data related to billing or payments. Your name, billing address, and credit card details are all financial data processed by Stripe which is a highly reputable e-commerce platform which uses industry standard security practices to encrypt your payment and billing data. Additionally, we do not collect any data about how or when you use the Foundry Virtual Tabletop software.</p>
-<p>The data we store is kept securely in a secured database using modern web security and encryption standards. We do not sell, trade, or transfer any of your personally identifiable information to outside parties aside from what is explicitly mentioned in this document.</p>
+<p>We do NOT collect or store any data related to financial transactions. Your name, billing address, and credit card details are all financial data processed by Stripe which is a highly reputable and secure e-commerce platform. Stripe encrypts your payment and billing data and stores it following industry-leading security practices.</p>
+<p>The data we do retain is stored in a private database protected using modern web security and encryption standards. We do not sell, trade, or transfer any individual data to outside parties aside from what is explicitly mentioned in this document.</p>
 
 <blockquote class="question">How can I change my personal information or request that it be deleted?</blockquote>
 <p>You have the rights to view, modify, or delete your personal data at any time. You may view your personal data on your website user profile page, where you may also modify that data. To request the deletion of personal data, or the deletion of your website account you may send an email to <a href="mailto:admin@foundryvtt.com?subject=Personal Data Deletion Request">admin@foundryvtt.com</a> from the email address associated with your website account.</p>
 
 <h2 class="border">Contacting Us</h2>
-<p>If you have any questions about this privacy policy you may contact us using the information below:</p>
+<p>If you have any questions about this privacy policy you may contact us using the information below. Please note that we offer the fastest response time to email correspondence.</p>
 <p>Foundry Gaming LLC<br/>522 W Riverside Ave, STE N<br/>Spokane, WA 99201-4540<br/>United States<br/>UBI 6504340383</p>
-<p><a href="mailto:admin@foundryvtt.com?subject=Personal Data Deletion Request">admin@foundryvtt.com</a></p>
-
-<p class="note">Foundry Gaming LLC © 2022. Privacy Policy</p>
+<p><a href="mailto:admin@foundryvtt.com?subject=Privacy Policy">admin@foundryvtt.com</a></p>


### PR DESCRIPTION
Changes to our policies to address the following issues:

## EULA Changes
1. Document optional usage data sharing enabled by https://github.com/foundryvtt/foundryvtt/issues/8912
2. Add clarification to the EULA that selling *access* to the software is not permitted
3. Add a clause to the EULA that illegal distribution of copyright-protected materials is not permitted
4. Add the previously implicit requirement that licensed users must maintain a user account on the foundryvtt.com website
5. Improve various cases where language could be improved to be more accurate or transparent
6. Improve links to Refund Request Form, License Transfer Form, and other foundryvtt.com website links

## Privacy Policy Changes
1. Document optional usage data sharing enabled by https://github.com/foundryvtt/foundryvtt/issues/8912
2. Provide a real example of usage data that would be shared if allowed
3. Reorganize the policy to separate Foundry Virtual Tabletop Software and Foundry Virtual Tabletop Website sections
